### PR TITLE
Add minimal C# API backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,23 @@ General-purpose utility functions such as formatting dates, generating UUIDs, va
 ---
 
 This structure is flexible and can be adjusted as the application grows.
+
+## Backend API
+
+A minimal API built with ASP.NET Core is included in the `backend` folder. The API provides stub endpoints for authentication, vehicle listings, and bookings.
+
+### Building and running
+
+1. Install the [.NET SDK](https://dotnet.microsoft.com/download) (version 8.0 or later).
+2. Navigate to the `backend` directory.
+3. Run `dotnet run` to start the API on `https://localhost:5001` or `http://localhost:5000`.
+
+### Endpoints
+
+- `POST /auth/login` – returns a fake token and user information.
+- `POST /auth/register` – returns a fake token and created user.
+- `GET /vehicles` – retrieves a list of sample vehicles.
+- `GET /vehicles/{id}` – retrieves a vehicle by its id.
+- `POST /bookings` – submits a booking request and returns the created booking.
+
+These endpoints are placeholders intended for front‑end development and can be replaced with real implementations later.

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+
+var app = builder.Build();
+
+app.MapGet("/", () => "RideOn API running");
+
+record User(string Id, string Email);
+record Vehicle(string Id, string Model, string Location, decimal PricePerDay);
+record BookingRequest(string VehicleId, string UserId, DateTime StartDate, DateTime EndDate);
+
+var vehicles = new List<Vehicle>
+{
+    new("1", "Honda Wave", "Hanoi", 100),
+    new("2", "Yamaha Exciter", "Ho Chi Minh City", 150),
+};
+
+var bookings = new List<object>();
+
+app.MapPost("/auth/login", (string email, string password) =>
+{
+    return Results.Ok(new { token = "fake-token", user = new User("1", email) });
+});
+
+app.MapPost("/auth/register", (string email, string password) =>
+{
+    return Results.Ok(new { token = "fake-token", user = new User("1", email) });
+});
+
+app.MapGet("/vehicles", () => vehicles);
+
+app.MapGet("/vehicles/{id}", (string id) =>
+{
+    var vehicle = vehicles.FirstOrDefault(v => v.Id == id);
+    return vehicle is not null ? Results.Ok(vehicle) : Results.NotFound();
+});
+
+app.MapPost("/bookings", (BookingRequest request) =>
+{
+    var booking = new
+    {
+        Id = Guid.NewGuid().ToString(),
+        request.VehicleId,
+        request.UserId,
+        request.StartDate,
+        request.EndDate
+    };
+    bookings.Add(booking);
+    return Results.Ok(booking);
+});
+
+app.Run();

--- a/backend/RideonApi.csproj
+++ b/backend/RideonApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- create `backend` folder with `RideonApi.csproj` and a minimal ASP.NET Core API
- document API usage in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: numerous TS7026 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856a48e80448320a40fd1a7dd85b2d5